### PR TITLE
Removes unnecessary branch on docker-build trigger

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [main, cht-cms-rds-108]
+    branches: [main]
   # Also trigger on release created event
   release:
     types: [published]


### PR DESCRIPTION
This PR ended up being way shorter than expected. Just cleaning up the extra branch from the docker-build.yml