### PR TITLE
Make sure we have AWS, refactor how we build/test

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,13 +31,6 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: docker build . --file Dockerfile --tag $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest --tag $ECR_REGISTRY/$ECR_REPOSITORY:${HASH}
-      - name: Test the Docker image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "aws --version"
-          docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "git --version"
-          docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "cinc-auditor --version"
       - name: Push docker image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,21 @@
 FROM ruby:2.6.7-alpine3.13
 
 ARG CINC_VERSION="4.22.0"
+ARG GLIBC_VERSION="2.33-r0"
+
 ARG GEM_SOURCE=https://packagecloud.io/cinc-project/stable
 ARG RUNUSER=default
 ARG RUNGROUP=default
 
-# install dependencies (some temporarily)
-# install cinc-auditor
-# clone the CMS profile
-# create user
-# clean up
-RUN apk add --update --no-cache --virtual .build-deps \
-      build-base gcc musl-dev openssl-dev \
-      libxml2-dev libffi-dev libstdc++ git \
-    && apk add --update --no-cache --virtual .run-deps bash mysql-client \
-    && gem install --no-document --source ${GEM_SOURCE} \
-      --version ${CINC_VERSION} cinc-auditor-bin \
-    && mkdir -p /home/${RUNUSER}/profiles \
-    && cd /home/${RUNUSER}/profiles \
-    && git clone https://github.com/CMSgov/cms-ars-3.1-moderate-aws-rds-oracle-mysql-ee-5.7-cis-overlay.git \
-    && addgroup -g 1000 ${RUNUSER} && adduser -u 1000 -G ${RUNUSER} -s /bin/sh -D ${RUNUSER} \
-    && chown -R ${RUNUSER}:${RUNGROUP} /home/${RUNUSER} \
-    && apk del --no-cache .build-deps \
-    && rm -rf /tmp/* \
-    && rm -rf /var/cache/apk/* \
-    && rm -rf /var/tmp/*
+COPY build.sh /tmp
+COPY tests.sh /tmp
+
+RUN /tmp/build.sh
 
 COPY --chown=${RUNUSER}:${RUNGROUP} inputs.yml.erb /home/${RUNUSER}/profiles/cms-ars-3.1-moderate-aws-rds-oracle-mysql-ee-5.7-cis-overlay/
 COPY --chown=${RUNUSER}:${RUNGROUP} scriptRunner.sh /home/${RUNUSER}/profiles
+
+RUN /tmp/tests.sh && rm -rf /tmp/*
 
 WORKDIR /home/${RUNUSER}
 USER ${RUNUSER}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -euox pipefail
+
+# install our dependencies
+apk add --update --no-cache --virtual .build-deps \
+      build-base gcc musl-dev openssl-dev curl \
+      libxml2-dev libffi-dev libstdc++ git
+apk add --update --no-cache --virtual .run-deps bash mysql-client
+
+# install cinc-auditor
+gem install --no-document --source "${GEM_SOURCE}" \
+      --version "${CINC_VERSION}" cinc-auditor-bin
+
+# install glibc for awscliv2
+curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub
+curl -sLO "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk"
+curl -sLO "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk"
+apk add --update --no-cache --virtual .glibc \
+      "glibc-${GLIBC_VERSION}.apk" \
+      "glibc-bin-${GLIBC_VERSION}.apk"
+
+# Install awscliv2
+curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
+unzip awscliv2.zip
+./aws/install
+
+# install mysql profile and add our user
+addgroup -g 1000 "${RUNUSER}" && adduser -u 1000 -G "${RUNUSER}" -s /bin/sh -D "${RUNUSER}"
+mkdir -p "/home/${RUNUSER}/profiles"
+(cd "/home/${RUNUSER}/profiles" && \
+  git clone https://github.com/CMSgov/cms-ars-3.1-moderate-aws-rds-oracle-mysql-ee-5.7-cis-overlay.git)
+chown -R "${RUNUSER}":"${RUNGROUP}" "/home/${RUNUSER}"
+
+# clean up
+apk del --no-cache .build-deps
+rm -rf /var/cache/apk/*
+rm -rf /var/tmp/*
+rm -rf "./*-${GLIBC_VERSION}.apk"
+rm -rf \
+      awscliv2.zip \
+      aws \
+      /usr/local/aws-cli/v2/*/dist/aws_completer \
+      /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+      /usr/local/aws-cli/v2/*/dist/awscli/examples

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+set -oe pipefail
+
+aws --version
+cinc-auditor --version


### PR DESCRIPTION
- pulls the tests out of github actions workflow, and directly into the docker build
- does our build layer in a script rather than doing it direct in the Dockerfile
- adds in glibc, which is required for AWS cli v2
- add in AWS cli v2 so we can still publish to S3