### PR TITLE
Cleaning up some code for legibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,5 @@ RUN /tmp/tests.sh && rm -rf /tmp/*
 
 WORKDIR /home/${RUNUSER}
 USER ${RUNUSER}
+
+ENTRYPOINT ["./profiles/scriptRunner.sh"]

--- a/main.tf
+++ b/main.tf
@@ -49,19 +49,6 @@ data "aws_iam_policy_document" "ecr_perms_ro_cross_account" {
   }
 
   statement {
-    sid = ""
-
-    effect = "Allow"
-
-    actions = ["ecr:GetAuthorizationToken"]
-
-    principals {
-      identifiers = concat([var.ci_user_arn], var.allowed_read_principals)
-      type        = "AWS"
-    }
-  }
-
-  statement {
     sid = "githubCIPermissions"
 
     effect = "Allow"
@@ -78,6 +65,7 @@ data "aws_iam_policy_document" "ecr_perms_ro_cross_account" {
       "ecr:CompleteLayerUpload",
       "ecr:BatchGetImage",
       "ecr:BatchCheckLayerAvailability",
+      "ecr:GetAuthorizationToken"
     ]
 
     principals {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,16 @@ variable "container_name" {
   description = "Container name"
 }
 
+variable "allowed_read_principals" {
+  type        = list
+  description = "External principals that are allowed to read from the ECR repository"
+}
+
+variable "ci_user_arn" {
+  type        = string
+  description = "ARN for CI user which has read/write permissions"
+}
+
 variable "lifecycle_policy" {
   type        = string
   description = "ECR repository lifecycle policy document. Used to override the default policy."
@@ -19,14 +29,4 @@ variable "scan_on_push" {
   type        = bool
   description = "Scan image on push to repo."
   default     = true
-}
-
-variable "allowed_read_principals" {
-  type        = list
-  description = "External principals that are allowed to read from the ECR repository"
-}
-
-variable "ci_user_arn" {
-  type        = string
-  description = "ARN for CI user which has read/write permissions"
 }


### PR DESCRIPTION
Since these repositories may be used as examples of configuring an InSpec profile, just doing a bit of code cleanup.

- Placed the Entrypoint back into the Dockerfile
- Reorganized the main.tf cross account statement to remove a repetitive statement
- Reorganized variables in required first order

Verified functionality is intact:
![image](https://user-images.githubusercontent.com/61299314/123472690-7f8aab80-d5c5-11eb-916c-d54b3d5060b0.png)
